### PR TITLE
Extractions and Repacker fix

### DIFF
--- a/DRPExtractor/Program.cs
+++ b/DRPExtractor/Program.cs
@@ -24,13 +24,29 @@ namespace DRPExtractor
             }
 
             var drp = new DRPFile(args[0]);
+            int loopcount = 0;
 
             Directory.CreateDirectory(Path.GetFileNameWithoutExtension(args[0]));
             foreach(var entry in drp.ExtractFiles())
             {
-                var data = Util.DeCompress(entry.Value);
-                var path = Path.Combine(Path.GetFileNameWithoutExtension(args[0]), entry.Key);
-                File.WriteAllBytes(path, data);
+                if (drp.Entries.Count > loopcount)
+                {
+                    var specificEntry = drp.Entries.ElementAt(loopcount).Value;
+                    if (specificEntry.Unk == 0)
+                    {
+                        int isCompressed = specificEntry.Unk;
+                        var data = entry.Value;
+                        var path = Path.Combine(Path.GetFileNameWithoutExtension(args[0]), entry.Key);
+                        File.WriteAllBytes(path, data);
+                    }
+                    else
+                    {
+                        var data = Util.DeCompress(entry.Value);
+                        var path = Path.Combine(Path.GetFileNameWithoutExtension(args[0]), entry.Key);
+                        File.WriteAllBytes(path, data);
+                    }
+                }
+                loopcount++;
             }
         }
     }

--- a/DRPExtractor/Program.cs
+++ b/DRPExtractor/Program.cs
@@ -25,23 +25,29 @@ namespace DRPExtractor
 
             var drp = new DRPFile(args[0]);
             int loopcount = 0;
+            var specificEntry = drp.Entries.ElementAt(loopcount).Value;
+            int NumOfEntries = drp.Entries.Count;
 
             Directory.CreateDirectory(Path.GetFileNameWithoutExtension(args[0]));
             foreach(var entry in drp.ExtractFiles())
             {
-                if (drp.Entries.Count > loopcount)
+                if (specificEntry.Subfiles > 1)
                 {
-                    var specificEntry = drp.Entries.ElementAt(loopcount).Value;
-                    if (specificEntry.Unk == 0)
+                    NumOfEntries = NumOfEntries + (specificEntry.Subfiles - 1) ;
+                }
+                
+                if (NumOfEntries > loopcount)
+                {    
+                    if (specificEntry.Unk == 1)
                     {
-                        int isCompressed = specificEntry.Unk;
-                        var data = entry.Value;
+                        var data = Util.DeCompress(entry.Value);
                         var path = Path.Combine(Path.GetFileNameWithoutExtension(args[0]), entry.Key);
                         File.WriteAllBytes(path, data);
                     }
                     else
-                    {
-                        var data = Util.DeCompress(entry.Value);
+                    {                        
+                        int isCompressed = specificEntry.Unk;
+                        var data = entry.Value;
                         var path = Path.Combine(Path.GetFileNameWithoutExtension(args[0]), entry.Key);
                         File.WriteAllBytes(path, data);
                     }

--- a/DRPRepacker/DRPFile.cs
+++ b/DRPRepacker/DRPFile.cs
@@ -63,9 +63,16 @@ namespace DRPRepacker
                 return false;
 
             DRPEntry entry = Entries[file];
-            byte[] cdata = Util.Compress(data);
-
-            entry.Files[partNum] = new DRPFileEntry(cdata, data.Length);
+            if (entry.Unk == 1)
+            {
+                byte[] cdata = Util.Compress(data);
+                entry.Files[partNum] = new DRPFileEntry(cdata, data.Length);
+            }
+            else
+            {
+                byte[] cdata = data;
+                entry.Files[partNum] = new DRPFileEntry(cdata, data.Length);
+            }
             return true;
         }
         public Dictionary<string, byte[]> ExtractFiles()


### PR DESCRIPTION
Here are a few rough fixes to allow the program to extract most of the DRPs that were previously not extractable, code is a bit messy since I don't really have much experience on C#.  I have provided my findings and solutions within the descriptions of the commits below.

**Overview**
DRP Extractor :
1. Entry offset fix, some stage drp should now be extractable with the changes. 
2. Check for the value of unk of drp as that determines if the file is compressed or not, this should allow some of the chrind files to be fully extracted instead of having only bindpose and helperbone extracted.

DRP Repacker :
1. Don't compress files with unk value of 0.